### PR TITLE
Removed Cloud Provider switch logic

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,8 +1,6 @@
 BUCKET_NAME = "couchmart"
 # The list of nodes to use as 'AWS' nodes
 AWS_NODES = ["10.142.170.101", "10.142.170.102"]
-# The list of nodes to use as 'Azure' nodes
-AZURE_NODES = [""]
 # Whether the current cluster is on AWS
 AWS = True
 # Username of the data user

--- a/web-server.py
+++ b/web-server.py
@@ -26,13 +26,9 @@ socket_list = []
 bucket_name = settings.BUCKET_NAME
 user = settings.USERNAME
 password = settings.PASSWORD
+nodes = ','.join(settings.AWS_NODES)
 
-if settings.AWS:
-    node = settings.AWS_NODES[0]
-else:
-    node = settings.AZURE_NODES[0]
-
-bucket = Bucket('couchbase://{0}/{1}'.format(node, bucket_name),
+bucket = Bucket('couchbase://{0}/{1}'.format(nodes, bucket_name),
                 username=user, password=password)
 fts_nodes = None
 fts_enabled = False


### PR DESCRIPTION
Removed the Azure section from the settings file.
Removed the logic which checked and switched the node to connect.
Replaced with string which accumulates and targets all nodes in the cluster.